### PR TITLE
Added a text rendering upstream generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 *.test
 *.test.exe
 imagestuff
+*.ttf

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Photerm has various CLI arguments for altering the output.
 To save the output, simply redirect it to a txt file. The image can then be rerendered any time by printing the file in the terminal.
 
 ```
-Usage: main.exe [--scale SCALE] [--wide-boyz WIDE-BOYZ] [--in] [--mode MODE] [--Charset CHARSET] [--y-org Y-ORG] [--height HEIGHT] [--x-org X-ORG] [--width WIDTH] [--hue HUE] [PATH]
+Usage: main [--scale SCALE] [--wide-boyz WIDE-BOYZ] [--in] [--mode MODE] [--Charset CHARSET] [--custom CUSTOM] [--y-org Y-ORG] [--height HEIGHT] [--x-org X-ORG] [--width WIDTH] [--hue HUE] [--fps FPS] [PATH]
 
 Positional arguments:
   PATH                   file path for an image
@@ -37,15 +37,16 @@ Options:
   --scale SCALE, -s SCALE
                          overall image scale [default: 1.0]
   --wide-boyz WIDE-BOYZ, -w WIDE-BOYZ
-	                         How wide you want it guv? (Widens the image) [default: 1.0]
+                         How wide you want it guv? (Widens the image) [default: 1.0]
   --in, -i               read from stdin
   --mode MODE, -m MODE   mode selection determines renderer [default: A]
   --Charset CHARSET, -c CHARSET
                          Charset selection determines the character set used by the renderer [default: 0]
+  --custom CUSTOM        provide a custom string to render with [default: █]
   --y-org Y-ORG          minimum Y, top of focus [default: 0]
   --height HEIGHT        height, vertical size of focus [default: 0]
   --x-org X-ORG          minimum X, left edge of focus [default: 0]
   --width WIDTH          width, width of focus [default: 0]
   --hue HUE              hue rotation angle in radians [default: 0.0]
-  --help, -h             display this help and exit
+  --fps FPS              Provide an integer number of frames per second as an upper limit to the playback speed
 ```

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,10 @@ go 1.18
 
 require (
 	github.com/alexflint/go-arg v1.4.3
+	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/ungerik/go3d v0.0.0-20220309204530-55ced4bcb334
+	golang.org/x/image v0.0.0-20220722155232-062f8c9fd539
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/alexflint/go-scalar v1.1.0/go.mod h1:LoFvNMqS1CPrMVltza4LvnGKhaSpc3oy
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -16,6 +18,10 @@ github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMT
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ungerik/go3d v0.0.0-20220309204530-55ced4bcb334 h1:+pr8RFlV8713Uvkaxzwx/McFP5yxSC1TngTocIv6P2Q=
 github.com/ungerik/go3d v0.0.0-20220309204530-55ced4bcb334/go.mod h1:ipEjrk2uLK4xX8ivWBPIVOD0fMtKyPI0strluUfIlYQ=
+golang.org/x/image v0.0.0-20220722155232-062f8c9fd539 h1:/eM0PCrQI2xd471rI+snWuu251/+/jpBpZqir2mPdnU=
+golang.org/x/image v0.0.0-20220722155232-062f8c9fd539/go.mod h1:doUCurBvlfPMKfmIpRIywoHmhN3VyhnoFDbvIEWF4hY=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -390,5 +390,12 @@ func main() {
 
 		go photerm.Stream2Buf(buf, stream, Args)
 		util.Must(PlayFromBuff(buf, charset, Args.FrameRate))
+	case "T":
+		buf, err := photerm.Marquee(os.Stdin, 100)
+		if err != nil {
+			log.Fatal(err)
+		}
+		buf = photerm.AppendScalingStep(buf, Args)
+		util.Must(PlayFromBuff(buf, charset, Args.FrameRate))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -396,7 +396,7 @@ func main() {
 		util.Must(PlayFromBuff(buf, charset, Args.FrameRate))
 	case "T":
 		// here we create the marquee image source to read text from the stdin
-		buf, err := photerm.Marquee(os.Stdin, 100)
+		buf, err := photerm.Marquee(os.Stdin, 100, 8)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/main.go
+++ b/main.go
@@ -382,15 +382,20 @@ func main() {
 
 	case "S":
 		// S is the streaming mode!
+		// the async stream is represented by a <-chan []byte
 		stream, err := photerm.StreamMp4ToFrames(Args)
 		if err != nil {
 			log.Fatal(err)
 		}
 		buf := make(chan image.Image)
 
+		// here the stream is transformed into a <-chan image.Image
 		go photerm.Stream2Buf(buf, stream, Args)
+
+		// and the played out to the terminal
 		util.Must(PlayFromBuff(buf, charset, Args.FrameRate))
 	case "T":
+		// here we create the marquee image source to read text from the stdin
 		buf, err := photerm.Marquee(os.Stdin, 100)
 		if err != nil {
 			log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -394,6 +394,10 @@ func main() {
 
 		// and the played out to the terminal
 		util.Must(PlayFromBuff(buf, charset, Args.FrameRate))
+
+	// T stands for Text mode. Text mode expects string data from the stdin.
+	// This can be provided by pipe:
+	// 			$ echo 'foo' | photerm [ARGS]
 	case "T":
 		// here we create the marquee image source to read text from the stdin
 		buf, err := photerm.Marquee(os.Stdin, 100, 8)

--- a/photerm/photerm.go
+++ b/photerm/photerm.go
@@ -46,3 +46,24 @@ func ScaleImg(img image.Image, sf ScaleFactors) image.Image {
 	w, h := OutputDimsOf(sf, img)
 	return resize.Resize(w, h, img, resize.Lanczos2)
 }
+
+// ScaleTransform is ScaleImg wrapped as a pipeline step, i.e.
+// an async generator that has an input and an output.
+func ScaleTransform(
+	out chan<- image.Image,
+	in <-chan image.Image,
+	sf ScaleFactors,
+) {
+	defer close(out)
+	for img := range in {
+		out <- ScaleImg(img, sf)
+	}
+}
+
+// AppendScalingStep attaches the scaling pipeline step to the image buffer
+func AppendScalingStep(in <-chan image.Image, sf ScaleFactors) <-chan image.Image {
+	out := make(chan image.Image)
+	go ScaleTransform(out, in, sf)
+
+	return out
+}

--- a/photerm/text_source.go
+++ b/photerm/text_source.go
@@ -1,0 +1,225 @@
+package photerm
+
+import (
+	"fmt"
+	"image"
+	"image/draw"
+	"io"
+	"io/ioutil"
+	"log"
+	"strings"
+
+	"github.com/golang/freetype"
+	"github.com/golang/freetype/truetype"
+	"golang.org/x/image/font"
+)
+
+func NewCtx(f *truetype.Font, rgba draw.Image, pts float64) (ctx *freetype.Context) {
+	// Initialize the ctx.
+	fg, bg := image.White, image.Black
+	draw.Draw(rgba, rgba.Bounds(), bg, image.ZP, draw.Src)
+	ctx = freetype.NewContext()
+	ctx.SetDPI(72)
+	ctx.SetFont(f)
+	ctx.SetFontSize(pts)
+	ctx.SetClip(rgba.Bounds())
+	ctx.SetDst(rgba)
+	ctx.SetSrc(fg)
+	ctx.SetHinting(font.HintingFull)
+	return ctx
+}
+
+// TypeFace is the encapsulation of all of the information about the
+// geometry & scale of the font.
+type TypeFace struct {
+	Font *truetype.Font
+	Face font.Face
+}
+
+// ImageHeight returns the height bounding rectangle for any glyph in the font
+func (tf *TypeFace) ImageHeight() int {
+	return int(tf.Face.Metrics().Height)>>6 + int(tf.Face.Metrics().Descent)>>6
+}
+
+// ImageHeight returns the width bounding rectangle for any glyph in the font
+func (tf *TypeFace) ImageWidth() int {
+	w, ok := tf.Face.GlyphAdvance(' ')
+	if !ok {
+		log.Fatal("Could not get glyph width")
+	}
+
+	return int(w) >> 6
+}
+
+// Generators
+
+// These functions return a string channel read handle
+// that can be passed to GenImages
+
+// GenWords takes text and sends each word down the pipe one by one.
+func GenWords(text string) <-chan string {
+	work := func(out chan<- string, txt string) {
+		defer close(out)
+		for found := true; found; {
+			var word, rest string
+			word, rest, found = strings.Cut(txt, " ")
+			txt = string(rest)
+			out <- string(word)
+		}
+	}
+
+	res := make(chan string)
+	go work(res, text)
+	return res
+}
+
+// GenFixedWidth emulates a marquee by sending a fixed length substring
+// down the pipe with it's starting position incremented by one
+func GenFixedWidth(text string, width int) <-chan string {
+	text = strings.ReplaceAll(text, "\t", "    ")
+	work := func(out chan<- string, w int, t string) {
+		defer close(out)
+		glyphs := []rune(t)
+		for i := 0; i < len(glyphs)-w; i++ {
+			s := string(glyphs[i : i+w])
+			out <- s
+		}
+	}
+
+	results := make(chan string)
+	go work(results, width, text)
+
+	return results
+}
+
+// LoadTypeFace attempts to load the font at the path specified, and if successful, it returns the typeface, nil.
+// In case of an error, it returns nil, err.
+func LoadTypeFace(path string, size float64) (typeface *TypeFace, err error) {
+	// everything is declared at this point, so returning if
+	// err != nil will return nil, err
+	var fontBytes []byte
+
+	// Read the font data.
+	fontBytes, err = ioutil.ReadFile(path)
+	if err != nil {
+		return
+	}
+
+	// then parse it
+	f, err := freetype.ParseFont(fontBytes)
+	if err != nil {
+		return
+	}
+
+	face := truetype.NewFace(f, &truetype.Options{Size: size})
+
+	return &TypeFace{Font: f, Face: face}, nil
+}
+
+// LefToRightConcat concatenates the images passed with imgs[0] being the leftmost.
+func LefToRightConcat(imgs ...draw.Image) (concat draw.Image, err error) {
+	if len(imgs) == 0 {
+		return nil, fmt.Errorf("LefToRightConcat: Must supply at least one image")
+	}
+	cellWidth := imgs[0].Bounds().Dx()
+
+	width := 0
+	for _, nxt := range imgs {
+		width += nxt.Bounds().Dx()
+	}
+	concat = image.NewRGBA(
+		image.Rectangle{
+			image.Point{0, 0},
+			image.Point{
+				width,
+				imgs[0].Bounds().Dy(),
+			},
+		},
+	)
+
+	for i, nxt := range imgs {
+		draw.Draw(
+			concat,
+			nxt.Bounds().Add(image.Point{i * cellWidth, 0}),
+			nxt,
+			image.Point{0, 0},
+			draw.Src,
+		)
+	}
+
+	return
+}
+
+// GenImages takes a string generator and returns a image buffer, i.e. an instance of <-chan image.Image.
+// This buffer transports image.Image instances that are the png rendered text using the TypeFace.
+func GenImages(text <-chan string, pts float64, panningStep int) <-chan image.Image {
+	work := func(res chan<- image.Image, txt <-chan string, tf *TypeFace) {
+		defer close(res)
+		const smoothing = 2
+		imgs := []draw.Image{}
+		w, h := tf.ImageWidth(), tf.ImageHeight()
+		if panningStep == 0 {
+			panningStep = w
+		}
+		for x := range text {
+			for _, glyph := range x {
+				// create the rgba image
+				glyphImg := image.NewRGBA(image.Rect(0, 0, w, h))
+
+				// Initialise the ctx.
+				ctx := NewCtx(tf.Font, glyphImg, pts)
+				m := tf.Face.Metrics()
+				pixelHeight := int(m.Height) >> 6
+
+				// set the positioning
+				pt := freetype.Pt(0, pixelHeight)
+
+				// draw
+				ctx.DrawString(string(glyph), pt)
+				imgs = append(imgs, glyphImg)
+			}
+			// concatenate the images and...
+			concat, err := LefToRightConcat(imgs...)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			for i := 0; i < w; i += panningStep {
+				dstBounds := image.Rect( // The dimensions of the cropped image:
+					0,                      // left
+					0,                      // top
+					concat.Bounds().Dx()-w, // right
+					h,                      // btm
+				)
+				crop := image.NewRGBA(dstBounds)
+				croppingRect := dstBounds.Add(image.Point{i, 0})
+
+				draw.Draw(crop, crop.Bounds(), concat, croppingRect.Min, draw.Src)
+				res <- crop
+			}
+			// send concat!
+			imgs = []draw.Image{}
+		}
+
+	}
+
+	typeface, err := LoadTypeFace("./font.ttf", pts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	out := make(chan image.Image)
+	go work(out, text, typeface)
+
+	return out
+}
+
+func Marquee(from io.Reader, fontPts float64) (<-chan image.Image, error) {
+	text, err := ioutil.ReadAll(from)
+	if err != nil {
+		return nil, err
+	}
+	words := GenFixedWidth(string(text), 16)
+
+	return GenImages(words, fontPts, 4), nil
+}

--- a/photerm/text_source.go
+++ b/photerm/text_source.go
@@ -214,12 +214,12 @@ func GenImages(text <-chan string, pts float64, panningStep int) <-chan image.Im
 	return out
 }
 
-func Marquee(from io.Reader, fontPts float64) (<-chan image.Image, error) {
+func Marquee(from io.Reader, fontPts float64, letterWidth int) (<-chan image.Image, error) {
 	text, err := ioutil.ReadAll(from)
 	if err != nil {
 		return nil, err
 	}
-	words := GenFixedWidth(string(text), 16)
+	words := GenFixedWidth(string(text), letterWidth)
 
-	return GenImages(words, fontPts, 4), nil
+	return GenImages(words, fontPts, 1), nil
 }


### PR DESCRIPTION
### Changes

 - Adds a Marquee scrolling text image generator.
 - Added new mode `-m T` that expects text from the stdin (i.e. `echo 'some text goes here' | go run ./main.go -m T ...`)
 - Requires a font to be symlinked (or copied) into the current working directory as `font.ttf`.